### PR TITLE
This fixes the insecure content errors/warning on the example page.

### DIFF
--- a/index-jq.html
+++ b/index-jq.html
@@ -4,8 +4,8 @@
   <head>
     <link rel="stylesheet" href="css/ansi.css" type="text/css" media="all" />
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
-    <script src="http://code.jquery.com/jquery-migrate-1.2.1.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js" ></script>
+    <script src="//code.jquery.com/jquery-migrate-1.2.1.js"></script>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
     <script src="js/jqconsole.js"></script>
     <style>
@@ -62,11 +62,11 @@
         background-color: red;
       }
     </style>
-   <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />
-   <link rel="stylesheet" href="http://codemirror.net/lib/codemirror.css"/>
-    <script src="http://codemirror.net/lib/codemirror.js"></script>
-    <script type="text/javascript" src="http://codemirror.net/keymap/emacs.js"></script>
-    <script src="http://codemirror.net/mode/ruby/ruby.js"></script>
+   <link rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />
+   <link rel="stylesheet" href="//codemirror.net/lib/codemirror.css"/>
+    <script src="//codemirror.net/lib/codemirror.js"></script>
+    <script type="text/javascript" src="//codemirror.net/keymap/emacs.js"></script>
+    <script src="//codemirror.net/mode/ruby/ruby.js"></script>
     <script src="js/app-jqconsole.js"></script>
   </head>
   <body>


### PR DESCRIPTION
Assets aren't loading in Chrome browser because of an insecure content warning.

The page at 'https://fkchang.github.io/opal-irb/index-jq.html' was loaded over HTTPS, but ran insecure content from 'http://codemirror.net/keymap/emacs.js': this content should also be loaded over HTTPS.
